### PR TITLE
Update provider.tf for subscription_id within azurerm

### DIFF
--- a/panw-partner-wiki-main/contents/labs/access-key-rolling-blog/azure/provider.tf
+++ b/panw-partner-wiki-main/contents/labs/access-key-rolling-blog/azure/provider.tf
@@ -10,5 +10,6 @@ terraform {
 }
 
 provider "azurerm" {
+  subscription_id = " "
   features {}
 }


### PR DESCRIPTION
## Description

Terraform script failing for Azure provider (provider.tf) due to new requirement to have subscription_id defined.

## Motivation and Context

Change required in order for the terraform script to run without errors

## How Has This Been Tested?

Tested within the Azure UNTRUST environment 
Successfully provisioned all infrastructure

## Types of changes

Fixes new requirements for terraform azurerm provider
<!--- PICK ONE: -->

- Bug fix 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes if appropriate.
- [ x] All new and existing tests passed.
